### PR TITLE
improve_deployment

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.3"
+appVersion: "v0.4.4"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -68,3 +68,13 @@ Create the name of the tls secret for secure port
 {{- $fullname := include "boilerplate.fullname" . -}}
 {{- default (printf "%s-tls" $fullname) .Values.tls.secretName }}
 {{- end }}
+
+{{/*
+App environment variables
+*/}}
+{{- define "boilerplate.env" -}}
+{{- range $key, $val := .Values.env }}
+- name: {{ $key | quote }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{ include "boilerplate.env" . | indent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,7 +48,7 @@ tls:
   secretName:
 
 ingress:
-  enabled: true
+  enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
@@ -116,6 +116,11 @@ probes:
 
 # create Prometheus Operator monitor
 serviceMonitor:
-  enabled: false
+  enabled: true
   interval: 15s
   additionalLabels: {}
+
+# environment variables to pass to the container
+env: {
+    "ENV": "production"
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gophermodz/http/httpinfra"
 	"github.com/gorilla/mux"
 	"github.com/jessevdk/go-flags"
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
@@ -34,6 +34,11 @@ var opts struct {
 }
 
 func main() {
+	l := initLogger()
+	_, _ = maxprocs.Set(maxprocs.Logger(func(s string, i ...interface{}) {
+		l.Info(fmt.Sprintf(s, i...))
+	}))
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -44,8 +49,6 @@ func main() {
 		}
 		return
 	}
-
-	l := initLogger()
 
 	if err := run(ctx, l); err != nil {
 		l.Fatal("run failed", zap.Error(err))


### PR DESCRIPTION
This patch modifies the main function to initialize the logger before setting the maximum number of CPUs that can be used by the program. It also changes the import statement to import the `maxprocs` package directly instead of using a blank identifier. The logger is then used to log any messages from the `maxprocs.Set` function.